### PR TITLE
Add a way to use a separate serviceId and serviceName

### DIFF
--- a/src/main/java/org/irenical/healthy/Healthy.java
+++ b/src/main/java/org/irenical/healthy/Healthy.java
@@ -249,4 +249,11 @@ public class Healthy implements LifeCycle {
     return result;
   }
 
+  public String getServiceId() {
+    return serviceId;
+  }
+
+  public String getServiceName() {
+    return serviceName;
+  }
 }

--- a/src/test/java/org/irenical/healthy/HealthyTest.java
+++ b/src/test/java/org/irenical/healthy/HealthyTest.java
@@ -1,0 +1,47 @@
+package org.irenical.healthy;
+
+import org.irenical.lifecycle.LifeCycle;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class HealthyTest {
+
+  private static final String SERVICE_NAME = "testServiceName";
+
+  private static final String SERVICE_ID = "testServiceId";
+
+  @Test
+  public void testServiceIdDefaultsToServiceName() throws Exception {
+
+    final DummyLifeCycle dummyLifeCycle = new DummyLifeCycle();
+
+
+    Healthy instance = new Healthy(dummyLifeCycle, SERVICE_NAME, null);
+
+    assertEquals("serviceId should match provided serviceName", SERVICE_NAME, instance.getServiceId());
+    assertEquals("serviceName should match provided serviceName", SERVICE_NAME, instance.getServiceName());
+    assertEquals("serviceId should default to serviceName", instance.getServiceName(), instance.getServiceId());
+
+
+    Healthy anotherInstance = new Healthy(dummyLifeCycle, SERVICE_ID, SERVICE_NAME, null, null);
+
+    assertEquals("serviceId should match provided serviceId", SERVICE_ID, anotherInstance.getServiceId());
+    assertEquals("serviceName should match provided serviceName", SERVICE_NAME, anotherInstance.getServiceName());
+    assertNotEquals("serviceId should differ from serviceName", anotherInstance.getServiceName(), anotherInstance.getServiceId());
+  }
+
+  private static final class DummyLifeCycle implements LifeCycle {
+    @Override
+    public void start() {}
+
+    @Override
+    public void stop() {}
+
+    @Override
+    public boolean isRunning() {
+      return true;
+    }
+  }
+}


### PR DESCRIPTION
There are instances where the serviceName might not be enough to distinguish running nodes in the consul service registration. Having a unique id for each running instance then might be useful but Healthy provides no way to use it.

According to Consul docs:

> The id is set to the name if not provided. It is required that all services have a unique ID per node, so if names might conflict then unique IDs should be provided.

I've added an extra constructor parameter and defaulted the serviceId value to use the serviceName if none is provided.